### PR TITLE
Mostly spelling and formatting fixes

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -54,7 +54,7 @@ jobs:
               flex \
               libssl-dev \
               libgnutls28-dev
-      - run: ./scripts/build-atf.sh
+      - run: ./scripts/build-tf-a.sh
       - run: ./scripts/build-u-boot.sh
       - name: Upload bootloader binaries
         uses: actions/upload-artifact@v6

--- a/README.rst
+++ b/README.rst
@@ -1,37 +1,37 @@
 Debian on OpenWrt One
 ======================
 
-The `Openwrt One`_ is a nice open hardware access point, running
+The `OpenWrt One`_ is a nice open hardware access point, running
 OpenWrt by default. As the hardware is reasonably powerful and expandable,
 running a more general purpose OS like Debian on it can be rather convenient.
 
 The onboard storage (NAND) flash is 256MiB, which Debian can be made to fit.
 However it's somewhat inconvenient and limiting. Luckily there is an M.2 slot
-on the board to expand the storage via e.g. an NVME, which this repo helps
+on the board to expand the storage via e.g. an NVMe, which this repo helps
 installing Debian on.  **Note** The goal here is to just make it easy to
 install an initial Debian image on the OpenWrt One. Not to provide a polished
 end-user access-point experience, like e.g.  OpenWrt provides.
 
 Requirements:
 
-* OpenWrt one
-* NVME fitted in the device
+* OpenWrt One
+* NVMe fitted in the device
 * Serial console access (front type-c port, baudrate 115200)
 * USB stick for installation
 
 All artifacts for installation steps can be downloaded from the `latest build`_
 (`openwrt*`) and should be placed on a USB stick (single FAT partition).
 
-.. _OpenWrt one: https://openwrt.org/toh/openwrt/one
+.. _OpenWrt One: https://openwrt.org/toh/openwrt/one
 .. _latest build: https://github.com/sjoerdsimons/openwrt-one-debian/releases/tag/latest
 
 Installation:
 =============
 
 The installation comes in two parts; First the NAND flash content is replaced
-with a `u-boot` capable of directly booting from NVME as well as `recovery`
-image to help with flashing the NVME and potentially debugging system issues.
-As a second step a Debian `system` image will be installed to the NVME.
+with a `u-boot` capable of directly booting from NVMe as well as `recovery`
+image to help with flashing the NVMe and potentially debugging system issues.
+As a second step a Debian `system` image will be installed to the NVMe.
 
 Flashing NAND:
 --------------
@@ -55,10 +55,10 @@ Then to flash:
 * Remove power, switch boot selector back to NAND
 
 
-Flashing NVME:
+Flashing NVMe:
 --------------
 
-Now the NVME can be flashed, also from USB.
+Now the NVMe can be flashed, also from USB.
 
 * Format a USB stick with a single FAT partition
 * Download:
@@ -70,7 +70,7 @@ For flashing the recovery image should be booted from NAND:
 
 * Power on the device
 * On first boot `Bad EC magic` messages can be shown, this can be ignored
-* If there was no OS on the NVME, the system will automatically boot the
+* If there was no OS on the NVMe, the system will automatically boot the
   recovery image. Otherwise stop U-Boot and execute `run boot_recovery`
 * On boot a small flasher UI will show up on serial console.
 * Simply select an image to flash (detected on USB drive)

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Requirements:
 * USB stick for installation
 
 All artifacts for installation steps can be downloaded from the `latest build`_
-(`openwrt*`) and should be placed on a USB stick (single FAT partition).
+(`openwrt*`) and should be placed on a USB stick (single FAT or FAT32 partition).
 
 .. _OpenWrt One: https://openwrt.org/toh/openwrt/one
 .. _latest build: https://github.com/sjoerdsimons/openwrt-one-debian/releases/tag/latest
@@ -39,7 +39,7 @@ Flashing NAND:
 To (re)flash NAND, the system is booted from NOR flash and NAND rewritten
 from USB; To do this:
 
-* Format a USB stick with a single FAT partition
+* Format a USB stick with a single FAT or FAT32 partition
 * Download and put on the stick:
 
   * openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin
@@ -60,7 +60,7 @@ Flashing NVMe:
 
 Now the NVMe can be flashed, also from USB.
 
-* Format a USB stick with a single FAT partition
+* Format a USB stick with a single FAT or FAT32 partition
 * Download:
 
   * the system image (e.g. openwrt.img.zst)

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Requirements:
 * USB stick for installation
 
 All artifacts for installation steps can be downloaded from the `latest build`_
-(`openwrt*`) and should be placed on a USB stick (single FAT or FAT32 partition).
+(``openwrt*``) and should be placed on a USB stick (single FAT or FAT32 partition).
 
 .. _OpenWrt One: https://openwrt.org/toh/openwrt/one
 .. _latest build: https://github.com/sjoerdsimons/openwrt-one-debian/releases/tag/latest
@@ -29,9 +29,9 @@ Installation:
 =============
 
 The installation comes in two parts; First the NAND flash content is replaced
-with a `u-boot` capable of directly booting from NVMe as well as `recovery`
+with an ``u-boot`` capable of directly booting from NVMe as well as ``recovery``
 image to help with flashing the NVMe and potentially debugging system issues.
-As a second step a Debian `system` image will be installed to the NVMe.
+As a second step a Debian ``system`` image will be installed to the NVMe.
 
 Flashing NAND:
 --------------
@@ -42,8 +42,8 @@ from USB; To do this:
 * Format a USB stick with a single FAT or FAT32 partition
 * Download and put on the stick:
 
-  * openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin
-  * openwrt-mediatek-filogic-openwrt_one-factory.ubi
+  * ``openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin``
+  * ``openwrt-mediatek-filogic-openwrt_one-factory.ubi``
 
 Then to flash:
 
@@ -63,19 +63,19 @@ Now the NVMe can be flashed, also from USB.
 * Format a USB stick with a single FAT or FAT32 partition
 * Download:
 
-  * the system image (e.g. openwrt.img.zst)
-  * the associated bmap file (e.g. openwrt.img.bmap)
+  * the system image (e.g. ``openwrt-one-debian-<date>.img.zst``)
+  * the associated bmap file (e.g. ``openwrt-one-debian-<date>.img.bmap``)
 
 For flashing the recovery image should be booted from NAND:
 
 * Power on the device
-* On first boot `Bad EC magic` messages can be shown, this can be ignored
+* On first boot ``Bad EC magic`` messages can be shown, this can be ignored
 * If there was no OS on the NVMe, the system will automatically boot the
-  recovery image. Otherwise stop U-Boot and execute `run boot_recovery`
+  recovery image. Otherwise stop U-Boot and execute ``run boot_recovery``
 * On boot a small flasher UI will show up on serial console.
 * Simply select an image to flash (detected on USB drive)
 * Once flashing is done, hit enter to reboot into the Debian system!
-* On first boot systemd-firstboot will prompt for hostname, root shell,
+* On first boot ``systemd-firstboot`` will prompt for hostname, root shell,
   root password. Be aware the boot messages can somewhat hide it prompting to
   start.
 * Have fun!
@@ -88,14 +88,14 @@ Recovery image:
 
 The recovery image as part of the NAND image is simply a minimal Debian system
 running in memory. To access this system hit Ctrl-C when the flasher pops and
-it will boot through to a getty. Login with user `root`, password `root`. This
-can be used for analysing issues with the main installation. As it's a normal
+it will boot through to a getty. Login with user ``root``, password ``root``.
+This can be used for analysing issues with the main installation. As it's a normal
 Debian system, apt etc will work as expected. However as it's running from
 memory it's all ephemeral.
 
 Network wise *all* interfaces are configured to DHCP including wireless. For
-connect to wireless `iwd` is pre-installed. `wlan0` is the 2.4 Ghz interface,
-`wlan1` is 5Ghz. To connect to a wireless network::
+connect to wireless ``iwd`` is pre-installed. ``wlan0`` is the 2.4 Ghz interface,
+``wlan1`` is 5Ghz. To connect to a wireless network::
 
   # Get the available wireless networks
   iwctl station wlan1  get-networks
@@ -112,12 +112,12 @@ configuration.
 * Openssh server is installed. [#ssh]_
 * Hostapd with example setups for both wireless interfaces
 
-  * By default exposed as ssid `openwrt-debian` with PSK: `debian on openwrt one`
+  * By default exposed as ssid ``openwrt-debian`` with PSK: ``debian on openwrt one``
 
-* `systemd-networkd` for network configuration, by default:
+* ``systemd-networkd`` for network configuration, by default:
 
-  * `WAN` interface as DHCP
-  * `LAN` interfaced bridge with the wireless in `lanbr`. Also configured to DHCP
+  * ``WAN`` interface as DHCP
+  * ``LAN`` interfaced bridge with the wireless in ``lanbr``. Also configured to DHCP
 
 * default leds configured via an udev rule (leds.role)
 
@@ -133,7 +133,7 @@ configuration.
 Reverting to OpenWrt:
 =====================
 
-As the `NOR` flash isn't touched, to revert to OpenWrt simply use their `full
+As the ``NOR`` flash isn't touched, to revert to OpenWrt simply use their `full
 recovery instructions`_.
 
 .. _full recovery instructions: https://openwrt.org/toh/openwrt/one#boot_into_norfull_recovery_modeflash_nand_from_usb

--- a/README.rst
+++ b/README.rst
@@ -47,13 +47,19 @@ from USB; To do this:
 
 Then to flash:
 
+* Plug in the USB stick with the above mentioned files
 * Switch boot selector on the back from NAND to NOR
+* Press and hold the button on the front
 * Power on the device
 * Wait until the front leds turn on (all three)
-* Hold front key for a couple of seconds, until only the white LED is on
+* When only the white LED is on, you can release the button on the front
 * Wait for the flashing to finish, green LED will turn on
 * Remove power, switch boot selector back to NAND
 
+If this sounds similar to `Boot into NOR/full recovery mode`_ on the OpenWrt One
+'toh' page, that is not a coincidence.
+
+.. _Boot into NOR/full recovery mode: https://openwrt.org/toh/openwrt/one#boot_into_norfull_recovery_modeflash_nand_from_usb
 
 Flashing NVMe:
 --------------
@@ -68,6 +74,7 @@ Now the NVMe can be flashed, also from USB.
 
 For flashing the recovery image should be booted from NAND:
 
+* Plug in the USB stick with the above mentioned files
 * Power on the device
 * On first boot ``Bad EC magic`` messages can be shown, this can be ignored
 * If there was no OS on the NVMe, the system will automatically boot the

--- a/scripts/build-tf-a.sh
+++ b/scripts/build-tf-a.sh
@@ -6,7 +6,7 @@ fi
 
 pushd arm-trusted-firmware
 
-echo "==== Build ATF for SNAND ===="
+echo "==== Build TF-A for SNAND ===="
 make -j $(nproc) PLAT=mt7981 USE_MKIMAGE=1 \
   BOOT_DEVICE=spim-nand  \
   UBI=1 OVERRIDE_UBI_START_ADDR=0x100000 \
@@ -20,7 +20,7 @@ cp -v build/mt7981/release/bl2.img ../openwrt-mediatek-filogic-openwrt_one-snand
 # Loadable over uart
 cp -v build/mt7981/release/bl2.bin ../openwrt-mediatek-filogic-openwrt_one-snand-preloader.raw
 
-echo "==== Build ATF for UART DL ===="
+echo "==== Build TF-A for UART DL ===="
 make -j $(nproc) PLAT=mt7981  \
   BOOT_DEVICE=ram  \
   RAM_BOOT_UART_DL=1 \

--- a/scripts/build-u-boot.sh
+++ b/scripts/build-u-boot.sh
@@ -9,7 +9,7 @@ fi
 CURRENT_DIR="$(pwd)"
 
 if [ ! -f bl31.bin.xz ] ; then
-  echo "Build ATF first!"
+  echo "Build TF-A first!"
   exit 1
 fi
 


### PR DESCRIPTION
This PR consists of the following commits:

- build: Rename 'atf' to 'TF-A'
- README: Fix OpenWrt One and NVMe spelling
- README: Clarify that FAT32 is supported too
- README: Use '``' instead of '`' to mark inline 'code'
- README: Extend and clarify the flashing instructions
